### PR TITLE
hotfix/iterate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XAM"
 uuid = "d759349c-bcba-11e9-07c2-5b90f8f05f7c"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"

--- a/src/bam/overlap.jl
+++ b/src/bam/overlap.jl
@@ -47,7 +47,7 @@ end
 
 function Base.iterate(iter::OverlapIterator)
     refindex = findfirst(isequal(iter.refname), iter.reader.refseqnames)
-    if refindex == 0
+    if refindex === nothing
         throw(ArgumentError("sequence name $(iter.refname) is not found in the header"))
     end
     @assert iter.reader.index !== nothing


### PR DESCRIPTION
This PR implements an iterator bug fix that was made apparent by @yuifu in #11. The fix only addresses the existing code and not the behaviour of the `OverlapIterator`, which I think is up for debate.
