### PR TITLE
Amend field access errors

### DIFF
--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -58,12 +58,10 @@
         @test ! BAM.ispositivestrand(record)
         @test BAM.refname(record) == "CHROMOSOME_I"
         @test BAM.refid(record) === 1
-        @test BAM.hasnextrefid(record)
-        @test BAM.nextrefid(record) === 0
+        @test ! BAM.hasnextrefid(record)
         @test BAM.hasposition(record) === hasleftposition(record) === true
         @test BAM.position(record) === leftposition(record) === 2
-        @test BAM.hasnextposition(record)
-        @test BAM.nextposition(record) === 0
+        @test ! BAM.hasnextposition(record)
         @test rightposition(record) == 102
         @test BAM.hastempname(record) === hasseqname(record) === true
         @test BAM.tempname(record) == seqname(record) == "SRR065390.14978392"


### PR DESCRIPTION
This PR amends various spec violations, see #24 . 

__NOTE__: These changes ARE breaking, depending on what you call "breaking". Previous code that did not error because of a nonsensical implementations may now error. For example, before this PR, the test BAM file ce1 of BioFmtSpecimens would return true for "hasnextmapped" and would return an out of bounds next mapping position of 0. Now `hasnextmapped` correctly returns false, and it will raise an error if you attempt to get the next mapping position.