### PR TITLE
Rehaul BAM and SAM accessor functions

### DIFF
--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -25,7 +25,11 @@ mutable struct Record
     reader::Union{Reader, Nothing}
 
     function Record()
-        return new(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, UInt8[])
+        # An empty record is a legitimate BAM record.
+        block_size = FIXED_FIELDS_BYTES - sizeof(Int32) + 1
+        # Only the null terminator of the query name sequence
+        data = UInt8[0x00]
+        return new(block_size, -1, -1, 0x01, 0xff, 0, 0, 0x0004, 0, -1, -1, 0, data, nothing)
     end
 end
 
@@ -77,46 +81,43 @@ function Base.copy(record::Record)
 end
 
 function Base.empty!(record::Record)
-    record.block_size = 0
-    record.refid      = 0
-    record.pos        = 0
-    record.l_read_name = 0
-    record.mapq = 0
-    record.bin = 0
-    record.flag = 0
-    record.n_cigar_op = 0
-    record.l_seq      = 0
-    record.next_refid = 0
-    record.next_pos   = 0
-    record.tlen       = 0
+    block_size         =  FIXED_FIELDS_BYTES - sizeof(Int32) + 1
+    record.block_size  = block_size
+    record.refid       = -1
+    record.pos         = -1
+    record.l_read_name = 0x01
+    record.mapq        = 0xff
+    record.bin         = 0
+    record.n_cigar_op  = 0
+    record.flag        = 0x0004
+    record.l_seq       = 0
+    record.next_refid  = -1
+    record.next_pos    = -1
+    record.tlen        = 0
+    record.data[1]     = 0x00
 
     #Note: data will be overwritten and indexed using data_size.
-    
     return record
 end
 
 function Base.show(io::IO, record::Record)
     print(io, summary(record), ':')
-    if isfilled(record)
-        println(io)
-        println(io, "      template name: ", tempname(record))
-        println(io, "               flag: ", flag(record))
-        println(io, "       reference ID: ", refid(record))
-        println(io, "           position: ", position(record))
-        println(io, "    mapping quality: ", mappingquality(record))
-        println(io, "              CIGAR: ", cigar(record))
-        println(io, "  next reference ID: ", nextrefid(record))
-        println(io, "      next position: ", nextposition(record))
-        println(io, "    template length: ", templength(record))
-        println(io, "           sequence: ", sequence(record))
-        # TODO: pretty print base quality
-        println(io, "       base quality: ", quality(record))
-          print(io, "     auxiliary data:")
-        for field in keys(auxdata(record))
-            print(io, ' ', field, '=', record[field])
-        end
-    else
-        print(io, " <not filled>")
+    println(io)
+    println(io, "      template name: ", tempname(record))
+    println(io, "               flag: ", flag(record))
+    println(io, "       reference ID: ", refid(record))
+    println(io, "           position: ", position(record))
+    println(io, "    mapping quality: ", mappingquality(record))
+    println(io, "              CIGAR: ", cigar(record))
+    println(io, "  next reference ID: ", nextrefid(record))
+    println(io, "      next position: ", nextposition(record))
+    println(io, "    template length: ", templength(record))
+    println(io, "           sequence: ", sequence(record))
+    # TODO: pretty print base quality
+    println(io, "       base quality: ", quality(record))
+      print(io, "     auxiliary data:")
+    for field in keys(auxdata(record))
+        print(io, ' ', field, '=', record[field])
     end
 end
 
@@ -134,12 +135,7 @@ end
 Get the bitwise flag of `record`.
 """
 function flag(record::Record)::UInt16
-    checkfilled(record)
     return record.flag
-end
-
-function hasflag(record::Record)
-    return isfilled(record)
 end
 
 """
@@ -182,24 +178,13 @@ The ID is 1-based (i.e. the first sequence is 1) and is 0 for a record without a
 
 See also: `BAM.rname`
 """
-function refid(record::Record)::Int
-    checkfilled(record)
-    return record.refid + 1
+function refid(record::Record)
+    hasrefid(record) || return nothing
+	return Int(record.refid + 1)
 end
 
 function hasrefid(record::Record)
-    return isfilled(record)
-end
-
-function checked_refid(record::Record)
-    id = refid(record)
-    if id == 0
-        throw(ArgumentError("record is not mapped"))
-    end
-    if !isdefined(record, :reader)
-        throw(ArgumentError("reader is not defined"))
-    end
-    return id
+	record.refid > -1
 end
 
 """
@@ -209,10 +194,9 @@ Get the reference sequence name of `record`.
 
 See also: `BAM.refid`
 """
-function refname(record::Record)::String
-    checkfilled(record)
-    id = checked_refid(record)
-    return record.reader.refseqnames[id]
+function refname(record::Record)
+    hasrefname(record) || return nothing
+    return record.reader.refseqnames[refid(record)]
 end
 
 """
@@ -220,14 +204,16 @@ end
 
 Get the length of the reference sequence this record applies to.
 """
-function reflen(record::Record)::Int
-    checkfilled(record)
-    id = checked_refid(record)
+function reflen(record::Record)
+	id = refid(record)
+	if (id === nothing) | (record.reader === nothing)
+		return nothing
+	end
     return record.reader.refseqlens[id]
 end
 
 function hasrefname(record::Record)
-    return hasrefid(record)
+    return hasrefid(record) & (record.reader !== nothing)
 end
 
 """
@@ -235,13 +221,12 @@ end
 
 Get the 1-based leftmost mapping position of `record`.
 """
-function position(record::Record)::Int
-    checkfilled(record)
-    return record.pos + 1
+function position(record::Record)
+	return hasposition(record) ? record.pos + 1 : nothing
 end
 
 function hasposition(record::Record)
-    return isfilled(record)
+	return record.pos > -1
 end
 
 """
@@ -249,13 +234,13 @@ end
 
 Get the 1-based rightmost mapping position of `record`.
 """
-function rightposition(record::Record)::Int
-    checkfilled(record)
-    return Int32(position(record) + alignlength(record) - 1)
+function rightposition(record::Record)
+    pos = position(record)
+    return pos === nothing ? nothing : pos + alignlength(record) - 1
 end
 
 function hasrightposition(record::Record)
-    return isfilled(record) && ismapped(record)
+    return record.pos > -1
 end
 
 """
@@ -263,8 +248,8 @@ end
 
 Test if the mate/next read of `record` is mapped.
 """
-function isnextmapped(record::Record)::Bool
-    return isfilled(record) && (flag(record) & SAM.FLAG_MUNMAP == 0)
+function isnextmapped(record::Record)
+    return flag(record) & SAM.FLAG_MUNMAP == 0
 end
 
 """
@@ -272,13 +257,16 @@ end
 
 Get the next/mate reference sequence ID of `record`.
 """
-function nextrefid(record::Record)::Int
-    checkfilled(record)
-    return record.next_refid + 1
+function nextrefid(record::Record)
+    ispaired = flag(record) & SAM.FLAG_PAIRED == SAM.FLAG_PAIRED
+    if !ispaired || record.next_refid == -1
+        return nothing
+    end
+    return Int(record.next_refid + 1)
 end
 
 function hasnextrefid(record::Record)
-    return isfilled(record)
+    return record.next_refid > -1
 end
 
 """
@@ -286,19 +274,14 @@ end
 
 Get the reference name of the mate/next read of `record`.
 """
-function nextrefname(record::Record)::String
-    checkfilled(record)
-    id = nextrefid(record)
-    if id == 0
-        throw(ArgumentError("next record is not mapped"))
-    elseif !isdefined(record, :reader)
-        throw(ArgumentError("reader is not defined"))
-    end
+function nextrefname(record::Record)
+    hasnextrefname(record) || return nothing
+    id = record.next_refid
     return record.reader.refseqnames[id]
 end
 
 function hasnextrefname(record::Record)
-    return isfilled(record) && isnextmapped(record)
+    return (record.next_refid > -1) & (record.reader !== nothing)
 end
 
 """
@@ -306,13 +289,13 @@ end
 
 Get the 1-based leftmost mapping position of the next/mate read of `record`.
 """
-function nextposition(record::Record)::Int
-    checkfilled(record)
+function nextposition(record::Record)
+    hasnextposition(record) || return nothing
     return record.next_pos + 1
 end
 
 function hasnextposition(record::Record)
-    return isfilled(record)
+    return record.next_pos > -1
 end
 
 """
@@ -320,12 +303,13 @@ end
 
 Get the mapping quality of `record`.
 """
-function mappingquality(record::Record)::UInt8
+function mappingquality(record::Record)
+    hasmappingquality(record) || return nothing
     return record.mapq
 end
 
 function hasmappingquality(record::Record)
-    return isfilled(record)
+    return record.mapq < 0xff
 end
 
 """
@@ -381,26 +365,27 @@ If you have a record that stores the true cigar in a `CG:B,I` tag, but you still
 See also `BAM.cigar`.
 """
 function cigar_rle(record::Record, checkCG::Bool = true)::Tuple{Vector{BioAlignments.Operation},Vector{Int}}
-    checkfilled(record)
     idx, nops = cigar_position(record, checkCG)
     ops, lens = extract_cigar_rle(record.data, idx, nops)
     return ops, lens
 end
 
-function extract_cigar_rle(data::Vector{UInt8}, offset, n)
-    ops = Vector{BioAlignments.Operation}()
-    lens = Vector{Int}()
-    for i in offset:4:offset + (n - 1) * 4
-        x = unsafe_load(Ptr{UInt32}(pointer(data, i)))
-        op = BioAlignments.Operation(x & 0x0F)
-        push!(ops, op)
-        push!(lens, x >> 4)
+function extract_cigar_rle(data::Vector{UInt8}, index, n)
+    ops = Vector{BioAlignments.Operation}(undef, n)
+    lens = Vector{Int}(undef, n)
+    GC.@preserve data @inbounds for i in 1:n
+        x = unsafe_load(Ptr{UInt32}(pointer(data, index)))
+        ops[i] = BioAlignments.Operation(x & 0x0F)
+        lens[i] = x >>> 4
+        index += 4
     end
     return ops, lens
 end
 
 function cigar_position(record::Record, checkCG::Bool = true)::Tuple{Int, Int}
-    cigaridx, nops = seqname_length(record) + 1, record.n_cigar_op
+    cigaridx, nops = seqname_length(record) + 2, record.n_cigar_op
+    # If a read has more than 65k ops, it's encoded in an AUX field, and the ops
+    # is set to kSmN. So first return if it's not that
     if !checkCG
         return cigaridx, nops
     end
@@ -411,6 +396,7 @@ function cigar_position(record::Record, checkCG::Bool = true)::Tuple{Int, Int}
     if x != UInt32(seqlength(record) << 4 | 4)
         return cigaridx, nops
     end
+    # Else we go fetch it from the AUX fields.
     start = auxdata_position(record)
     stop = data_size(record)
     tagidx = findauxtag(record.data, start, stop, UInt8('C'), UInt8('G'))
@@ -435,7 +421,6 @@ end
 Get the alignment of `record`.
 """
 function alignment(record::Record)::BioAlignments.Alignment
-    checkfilled(record)
     if !ismapped(record)
         return BioAlignments.Alignment(BioAlignments.AlignmentAnchor[])
     end
@@ -467,13 +452,14 @@ end
 
 Get the alignment length of `record`.
 """
-function alignlength(record::Record)::Int
-    offset = seqname_length(record)
-    length::Int = 0
-    for i in offset + 1:4:offset + n_cigar_op(record, false) * 4
-        x = unsafe_load(Ptr{UInt32}(pointer(record.data, i)))
+function alignlength(record::Record)
+    idx, nops = cigar_position(record, false)
+    length = 0
+    data = record.data
+    GC.@preserve data for i in 1:nops
+        x = unsafe_load(Ptr{UInt32}(pointer(record.data, idx)), i)
         op = BioAlignments.Operation(x & 0x0F)
-        if BioAlignments.ismatchop(op) || BioAlignments.isdeleteop(op)
+        if BioAlignments.ismatchop(op) | BioAlignments.isdeleteop(op)
             length += x >> 4
         end
     end
@@ -485,14 +471,13 @@ end
 
 Get the query template name of `record`.
 """
-function tempname(record::Record)::String
-    checkfilled(record)
-    # drop the last NUL character
-    return unsafe_string(pointer(record.data), max(seqname_length(record) - 1, 0))
+function tempname(record::Record)
+    hastempname(record) || return nothing
+    return unsafe_string(pointer(record.data), seqname_length(record))
 end
 
 function hastempname(record::Record)
-    return isfilled(record)
+    return seqname_length(record) > 0
 end
 
 """
@@ -500,13 +485,13 @@ end
 
 Get the template length of `record`.
 """
-function templength(record::Record)::Int
-    checkfilled(record)
+function templength(record::Record)
+    hastemplength(record) || return nothing
     return record.tlen
 end
 
 function hastemplength(record::Record)
-    return isfilled(record)
+    return record.tlen > 0
 end
 
 """
@@ -514,11 +499,12 @@ end
 
 Get the segment sequence of `record`.
 """
-function sequence(record::Record)::BioSequences.LongDNASeq
-    checkfilled(record)
+function sequence(record::Record)
+    hassequence(record) || return nothing
     seqlen = seqlength(record)
     data = Vector{UInt64}(undef, cld(seqlen, 16))
-    src::Ptr{UInt64} = pointer(record.data, seqname_length(record) + n_cigar_op(record, false) * 4 + 1)
+    index = seqname_length(record) + 1 + n_cigar_op(record, false) * 4 + 1
+    src::Ptr{UInt64} = pointer(record.data, index)
     for i in 1:lastindex(data)
         # copy data flipping high and low nybble
         x = unsafe_load(src, i)
@@ -528,7 +514,7 @@ function sequence(record::Record)::BioSequences.LongDNASeq
 end
 
 function hassequence(record::Record)
-    return isfilled(record)
+    return hasseqlength(record)
 end
 
 """
@@ -536,13 +522,13 @@ end
 
 Get the sequence length of `record`.
 """
-function seqlength(record::Record)::Int
-    checkfilled(record)
+function seqlength(record::Record)
+    hasseqlength(record) || return nothing
     return record.l_seq % Int
 end
 
 function hasseqlength(record::Record)
-    return isfilled(record)
+    return !iszero(record.l_seq)
 end
 
 """
@@ -551,14 +537,16 @@ end
 Get the base quality of `record`.
 """
 function quality(record::Record)
-    checkfilled(record)
+    hasseqlength(record) || return nothing
     seqlen = seqlength(record)
-    offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
-    return record.data[(1+offset):(seqlen+offset)]
+    offset = seqname_length(record) + 1 + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
+    quals = record.data[(1+offset):(seqlen+offset)]
+    all(i == 0xff for i in quals) && return nothing
+    return quals
 end
 
 function hasquality(record::Record)
-    return isfilled(record)
+    return hasseqlength(record) && any(i < 0xff for i in quality(record))
 end
 
 """
@@ -567,12 +555,11 @@ end
 Get the auxiliary data of `record`.
 """
 function auxdata(record::Record)
-    checkfilled(record)
     return AuxData(record.data[auxdata_position(record):data_size(record)])
 end
 
 function hasauxdata(record::Record)
-    return isfilled(record)
+    return auxdata_position(record) < data_size(record)
 end
 
 function Base.getindex(record::Record, tag::AbstractString)
@@ -610,7 +597,7 @@ function BioGenerics.seqname(record::Record)
 end
 
 function BioGenerics.hasseqname(record::Record)
-    return hastempname(record)
+        return hastempname(record)
 end
 
 function BioGenerics.sequence(record::Record)
@@ -643,26 +630,17 @@ end
 
 # Return the size of the `.data` field.
 function data_size(record::Record)
-    if isfilled(record)
-        return record.block_size - FIXED_FIELDS_BYTES + sizeof(record.block_size)
-    end
-
-    return 0
-
-end
-
-function checkfilled(record::Record)
-    if !isfilled(record)
-        throw(ArgumentError("unfilled BAM record"))
-    end
+    return record.block_size - FIXED_FIELDS_BYTES + sizeof(record.block_size)
 end
 
 function auxdata_position(record::Record)
     seqlen = seqlength(record)
-    return seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2) + seqlen + 1
+    seqlen === nothing && return 2
+    #      name                   null  CIGAR                           DNA              quals 
+    return seqname_length(record) + 1 + 4 * n_cigar_op(record, false) + cld(seqlen, 2) + seqlen + 1
 end
 
 # Return the length of the read name.
 function seqname_length(record::Record)
-    return record.l_read_name
+    return (record.l_read_name % Int) - 1
 end

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -35,9 +35,23 @@
 
     @testset "Record" begin
         record = BAM.Record()
-        @test !isfilled(record)
-        @test repr(record) == "XAM.BAM.Record: <not filled>"
-        @test_throws ArgumentError BAM.flag(record)
+        @test record == empty!(record)
+        @test BAM.flag(record) == 0x0004
+        @test !BAM.hasrefid(record)
+        @test !BAM.hasrefname(record)
+        @test !BAM.hasposition(record)
+        @test !BAM.hasrightposition(record)
+        @test !BAM.hasnextrefid(record)
+        @test !BAM.hasnextrefname(record)
+        @test !BAM.hasnextposition(record)
+        @test !BAM.hasmappingquality(record)
+        @test !BAM.hasalignment(record)
+        @test !BAM.hastempname(record)
+        @test !BAM.hasseqname(record)
+        @test !BAM.hassequence(record)
+        @test !BAM.hasquality(record)
+        @test !BAM.hasauxdata(record)
+        @test !BAM.hasnextrefid(record)
     end
 
     @testset "Reader" begin
@@ -58,12 +72,12 @@
         @test ! BAM.ispositivestrand(record)
         @test BAM.refname(record) == "CHROMOSOME_I"
         @test BAM.refid(record) === 1
-        @test BAM.hasnextrefid(record)
-        @test BAM.nextrefid(record) === 0
+        @test !BAM.hasnextrefid(record)
+        @test BAM.nextrefid(record) === nothing
         @test BAM.hasposition(record) === hasleftposition(record) === true
         @test BAM.position(record) === leftposition(record) === 2
-        @test BAM.hasnextposition(record)
-        @test BAM.nextposition(record) === 0
+        @test !BAM.hasnextposition(record)
+        @test BAM.nextposition(record) === nothing
         @test rightposition(record) == 102
         @test BAM.hastempname(record) === hasseqname(record) === true
         @test BAM.tempname(record) == seqname(record) == "SRR065390.14978392"


### PR DESCRIPTION
See also #24 and #25 .

This is a work in progress. In particular, I will *first* change the BAM code and get that right, and then afterwards change the SAM code to behave identically. Ideally, I would like SAM and BAM records to behave almost exactly identical, but that might not be feasible, let's see.

## Changes: (updated as I go along):
* Changes to "has"-functions, e.g. `hasposition` to always return a Bool
* Accessor functions now return what they're supposed to (see #24 )
* There are no more unfilled BAM records, so `isfilled` and `hasflag` has been removed

## Things to mull over
* Should we even have `has`-functions, or just return a specific sentinel value when the record doesn't have the information available, e.g. `nothing`? The latter may be neater.
* Which sentinel value? I'm leaning towards `nothing` (because it so qucikly errors if you dont handle it correctly, that leads to fewer bugs for the end user), but if you want `missing`, that's fine as well.