### PR TITLE
Upgrade to BioAlignments v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded to BioAlignments v3 ([#53](https://github.com/BioJulia/XAM.jl/pull/53))
+
 ## [0.3.0]
 
 ## Added

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 Automa = "0.7, 0.8"
 BGZFStreams = "0.3.1"
-BioAlignments = "2.2"
+BioAlignments = "3"
 BioGenerics = "0.1"
 BioSequences = "3"
 FormatSpecimens = "1.1"

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -430,27 +430,11 @@ end
 Get the alignment of `record`.
 """
 function alignment(record::Record)::BioAlignments.Alignment
-    checkfilled(record)
-    if !ismapped(record)
-        return BioAlignments.Alignment(BioAlignments.AlignmentAnchor[])
+    if ismapped(record)
+        return BioAlignments.Alignment(cigar(record), 1, position(record))
     end
-    seqpos = 0
-    refpos = position(record) - 1
-    anchors = [BioAlignments.AlignmentAnchor(seqpos, refpos, BioAlignments.OP_START)]
-    for (op, len) in zip(cigar_rle(record)...)
-        if BioAlignments.ismatchop(op)
-            seqpos += len
-            refpos += len
-        elseif BioAlignments.isinsertop(op)
-            seqpos += len
-        elseif BioAlignments.isdeleteop(op)
-            refpos += len
-        else
-            error("operation $(op) is not supported")
-        end
-        push!(anchors, BioAlignments.AlignmentAnchor(seqpos, refpos, op))
-    end
-    return BioAlignments.Alignment(anchors)
+
+    return BioAlignments.Alignment(BioAlignments.AlignmentAnchor[])
 end
 
 function hasalignment(record::Record)

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -79,10 +79,10 @@
         @test BAM.flag(record) === UInt16(16)
         @test BAM.cigar(record) == "27M1D73M"
         @test BAM.alignment(record) == Alignment([
-            AlignmentAnchor(  0,   1, OP_START),
-            AlignmentAnchor( 27,  28, OP_MATCH),
-            AlignmentAnchor( 27,  29, OP_DELETE),
-            AlignmentAnchor(100, 102, OP_MATCH)])
+            AlignmentAnchor(  0,   1,   0, OP_START),
+            AlignmentAnchor( 27,  28,  27, OP_MATCH),
+            AlignmentAnchor( 27,  29,  28, OP_DELETE),
+            AlignmentAnchor(100, 102, 101, OP_MATCH)])
         @test record["XG"] == 1
         @test record["XM"] == 5
         @test record["XN"] == 0

--- a/test/test_sam.jl
+++ b/test/test_sam.jl
@@ -104,10 +104,10 @@
         @test SAM.flag(record) == 16
         @test SAM.cigar(record) == "27M1D73M"
         @test SAM.alignment(record) == Alignment([
-            AlignmentAnchor(  0,   1, OP_START),
-            AlignmentAnchor( 27,  28, OP_MATCH),
-            AlignmentAnchor( 27,  29, OP_DELETE),
-            AlignmentAnchor(100, 102, OP_MATCH)])
+            AlignmentAnchor(  0,   1,   0, OP_START),
+            AlignmentAnchor( 27,  28,  27, OP_MATCH),
+            AlignmentAnchor( 27,  29,  28, OP_DELETE),
+            AlignmentAnchor(100, 102, 101, OP_MATCH)])
         @test record["XG"] == 1
         @test record["XM"] == 5
         @test record["XN"] == 0


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Updates the BioAlignments dependency compat bounds to `3`. Changes some cigar string handling to accommodate the change (see below).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.

## :racehorse: Addendum: performance considerations

I originally thought the implementation of constructing the alignment from the cigar string within XAM rather than passing off to BioAlignments was for performance reasons. I created a benchmark test to call `BAM.alignment` for every record in one of my longest/largest BAM files, and checked the performance. Results are below. Performance is unimpacted by this patch.

### XAM v0.3.0 (develop), BioAlignments v2.3.0

```plaintext
julia> @benchmark bam_perf_test()
BenchmarkTools.Trial: 62 samples with 1 evaluation.
 Range (min … max):  72.606 ms … 90.138 ms  ┊ GC (min … max): 0.00% … 2.20%
 Time  (median):     81.520 ms              ┊ GC (median):    2.40%
 Time  (mean ± σ):   81.684 ms ±  3.111 ms  ┊ GC (mean ± σ):  1.58% ± 1.22%

                      ▁ ▃▁     ▁█ ▃▁▆                          
  ▄▁▁▁▁▁▁▁▁▄▁▁▁▄▁▁▁▁▄▁█▄██▇▇▇▄▇██▄███▄▄▇▇▁▇▇▁▁▁▄▁▁▁▁▄▁▄▁▁▁▄▁▄ ▁
  72.6 ms         Histogram: frequency by time        89.7 ms <

 Memory estimate: 27.88 MiB, allocs estimate: 49550.
```

### XAM v0.3.0 (this patch), BioAlignments v2.3.0

```plaintext
julia> @benchmark bam_perf_test()
BenchmarkTools.Trial: 63 samples with 1 evaluation.
 Range (min … max):  72.161 ms … 104.476 ms  ┊ GC (min … max): 0.00% … 3.60%
 Time  (median):     79.874 ms               ┊ GC (median):    2.27%
 Time  (mean ± σ):   79.808 ms ±   3.660 ms  ┊ GC (mean ± σ):  1.50% ± 1.17%

                                  ▂▂   ▂      █ ▅ ▅ ▅▂▂ ▂       
  ▅▁▁▁▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁█▅▁▅██▅▅▅███▅▁▁████▅█████▅█▅█▁▁▅ ▁
  72.2 ms         Histogram: frequency by time         82.3 ms <

 Memory estimate: 27.88 MiB, allocs estimate: 49571.
```

### XAM v0.3.0 (this patch), BioAlignments v3.0.0

```plaintext
julia> @benchmark bam_perf_test()
BenchmarkTools.Trial: 63 samples with 1 evaluation.
 Range (min … max):  72.102 ms … 84.646 ms  ┊ GC (min … max): 0.00% … 2.45%
 Time  (median):     80.170 ms              ┊ GC (median):    2.34%
 Time  (mean ± σ):   80.134 ms ±  2.181 ms  ┊ GC (mean ± σ):  1.53% ± 1.20%

                                   █          ▃▃               
  ▄▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▁▄▁▁▁▁▁▁▁▁▁▁▁▆▆▇▆█▁▇▄▆▇▆▁▆▆▄██▇▄▆▇▄▁▆▄▁▁▁▁▆ ▁
  72.1 ms         Histogram: frequency by time        84.1 ms <

 Memory estimate: 27.88 MiB, allocs estimate: 49575.
```
