### PR TITLE
added method for handling different bam index types

### DIFF
--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -8,7 +8,7 @@ Create a data reader of the BAM file format.
 
 # Arguments
 * `input`: data source
-* `index=nothing`: filepath to a random access index (currently *bai* is supported)
+* `index=nothing`: filepath to a random access index (currently *bai* is supported) or BAI object 
 """
 mutable struct Reader{T} <: BioGenerics.IO.AbstractReader
     stream::BGZFStreams.BGZFStream{T}

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -28,13 +28,8 @@ function BioGenerics.IO.stream(reader::Reader)
 end
 
 function Reader(input::IO; index=nothing)
-    if isa(index, AbstractString)
-        index = BAI(index)
-    elseif index != nothing
-        error("unrecognizable index argument")
-    end
     reader = init_bam_reader(input)
-    reader.index = index
+    reader.index = init_bam_index(index)
     return reader
 end
 
@@ -125,6 +120,11 @@ function init_bam_reader(input::IO)
     return init_bam_reader(BGZFStreams.BGZFStream(input))
 end
 
+init_bam_index(index::AbstractString) = BAI(index)
+init_bam_index(index::BAI) = index
+init_bam_index(index::Nothing) = nothing
+init_bam_index(index) = error("unrecognizable index argument")
+    
 function _read!(reader::Reader, record)
     unsafe_read(
         reader.stream,

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -241,6 +241,21 @@
 
     end
 
+    @testset "BAI" begin
+
+        filepath = joinpath(bamdir, "GSE25840_GSM424320_GM06985_gencode_spliced.head.bam")
+
+        index = BAM.BAI(filepath * ".bai")
+        reader = open(BAM.Reader, filepath, index=index)
+        
+        @test isa(eachoverlap(reader, "chr1", 1:100), BAM.OverlapIterator)
+
+        close(reader)
+
+        @test_throws ErrorException open(BAM.Reader, filepath, index=1234) 
+
+    end
+
     @testset "Random access" begin
         filepath = joinpath(bamdir, "GSE25840_GSM424320_GM06985_gencode_spliced.head.bam")
         reader = open(BAM.Reader, filepath, index=filepath * ".bai")


### PR DESCRIPTION
This refactor a bit the BAM Reader interface to accept an already open index. I had some code where opening the index was the bottleneck, I could probably have rewritten it a bit to avoid creating several Readers but it's still good to support that case I think.

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
