### PR TITLE
Fix deprecated find in header docs

### DIFF
--- a/docs/src/man/hts-files.md
+++ b/docs/src/man/hts-files.md
@@ -67,7 +67,7 @@ end
 ## SAM and BAM Headers
 
 Both `SAM.Reader` and `BAM.Reader` implement the `header` function, which returns a `SAM.Header` object.
-To extract certain information out of the headers, you can use the `find` method on the header to extract information according to SAM/BAM tag.
+To extract certain information out of the headers, you can use the `findall` method on the header to extract information according to SAM/BAM tag.
 Again we refer you to the [specification](https://samtools.github.io/hts-specs/SAMv1.pdf) for full details of all the different tags that can occur in headers, and what they mean.
 
 Below is an example of extracting all the info about the reference sequences from the BAM header.
@@ -76,7 +76,7 @@ In SAM/BAM, any description of a reference sequence is stored in the header, und
 ```jlcon
 julia> reader = open(SAM.Reader, "data.sam");
 
-julia> find(header(reader), "SQ")
+julia> findall(SAM.header(reader), "SQ")
 7-element Array{Bio.Align.SAM.MetaInfo,1}:
  Bio.Align.SAM.MetaInfo:
     tag: SQ


### PR DESCRIPTION
Docs mention `find` for headers but one has to use `findall`.


