### PR TITLE
Do not allow unused trailing bytes in BAM records

### DIFF
--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -130,10 +130,8 @@ function _read!(reader::Reader, record)
         reader.stream,
         pointer_from_objref(record),
         FIXED_FIELDS_BYTES)
-    dsize = data_size(record)
-    if length(record.data) < dsize
-        resize!(record.data, dsize)
-    end
+    dsize = record.block_size - FIXED_FIELDS_BYTES + sizeof(record.block_size)
+    resize!(record.data, dsize)
     unsafe_read(reader.stream, pointer(record.data), dsize)
     record.reader = reader
     return record


### PR DESCRIPTION
Previously, the .data field of BAM records could have unused bytes near the end. This is acceptable, because the length of the actually used bytes is known from the fixed fields of the record.
It had the advantage of preventing frequent resizes, which was slow in Julia. However, from Julia 1.11 onwards, resizing is fast. Promising no non-coding bytes in the BAM records have the following advantages:
* It may simplify some code in XAM
* It allows an immutable struct holding a reference to the vector to resize the vector, signalling a change in the variable-length data.

This change is not user-facing and should be ready to merge.