### PR TITLE
XAM.isproperpair() fix

### DIFF
--- a/src/flags.jl
+++ b/src/flags.jl
@@ -71,7 +71,7 @@ end
 Query whether the segment is in a template where all segments are properly aligned according to the aligner.
 """
 function isproperpair(record::XAMRecord)::Bool
-    return flags(record) & PROPER_PAIR == PROPER_PAIR
+    return flags(record) & FLAG_PROPER_PAIR == FLAG_PROPER_PAIR
 end
 
 """


### PR DESCRIPTION
Use of `XAM.isproperpair(record)` returns:
```
UndefVarError: `PROPER_PAIR` not defined in `XAM`
```

I think the function should be using `FLAG_PROPER_PAIR` instead.

This PR implements the following changes:

* [X] :bug: Bug fix (A non-breaking change, which fixes an issue).
