### PR TITLE
switch BGZFStreams for BGZFLib

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.10' # LTS
+          - '1.11' # lowest compatible release
           - '1'
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6' # LTS
+          - '1.10' # LTS
           - '1'
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.4.2"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
-BGZFStreams = "28d598bf-9b8f-59f1-b38c-5a06b4a0f5e6"
+BGZFLib = "b86bd9b6-aa64-492d-a0e2-e61a004d8aed"
 BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
@@ -16,7 +16,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 Automa = "1"
-BGZFStreams = "0.3.1"
+BGZFLib = "0.1"
 BioAlignments = "3"
 BioGenerics = "0.1"
 BioSequences = "3"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ BioSequences = "3"
 FormatSpecimens = "1.1"
 GenomicFeatures = "2"
 Indexes = "0.1"
-MemoryViews = "0.4.1"
+MemoryViews = "0.4"
 TranscodingStreams = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ GenomicFeatures = "2"
 Indexes = "0.1"
 MemoryViews = "0.4"
 TranscodingStreams = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11"
-julia = "1.6"
+julia = "1.11"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XAM"
 uuid = "d759349c-bcba-11e9-07c2-5b90f8f05f7c"
-authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
 version = "0.4.2"
+authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
@@ -9,18 +9,24 @@ BGZFLib = "b86bd9b6-aa64-492d-a0e2-e61a004d8aed"
 BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"
 BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
+BufferIO = "ff366017-094f-4144-bd70-a828a0d67152"
 GenomicFeatures = "899a7d2d-5c61-547b-bef9-6698a8d05446"
 Indexes = "4ffb77ac-cb80-11e8-1b35-4b78cc642f6d"
 MemoryViews = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
+[weakdeps]
+BGZFStreams = "28d598bf-9b8f-59f1-b38c-5a06b4a0f5e6"
+
 [compat]
 Automa = "1"
+BGZFStreams = "0.3.1"
 BGZFLib = "0.1"
 BioAlignments = "3"
 BioGenerics = "0.1"
 BioSequences = "3"
+BufferIO = "0.2.5"
 FormatSpecimens = "1.1"
 GenomicFeatures = "2"
 Indexes = "0.1"
@@ -28,10 +34,13 @@ MemoryViews = "0.4"
 TranscodingStreams = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11"
 julia = "1.11"
 
+[extensions]
+BGZFStreamsExt = "BGZFStreams"
+
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FormatSpecimens = "3372ea36-2a1a-11e9-3eb7-996970b6ffbd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "FormatSpecimens", "Test"]
+test = ["Documenter", "FormatSpecimens", "Test", "BGZFStreams"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XAM"
 uuid = "d759349c-bcba-11e9-07c2-5b90f8f05f7c"
-authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
 version = "0.4.2"
+authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
@@ -11,6 +11,7 @@ BioGenerics = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 GenomicFeatures = "899a7d2d-5c61-547b-bef9-6698a8d05446"
 Indexes = "4ffb77ac-cb80-11e8-1b35-4b78cc642f6d"
+MemoryViews = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
@@ -23,6 +24,7 @@ BioSequences = "3"
 FormatSpecimens = "1.1"
 GenomicFeatures = "2"
 Indexes = "0.1"
+MemoryViews = "0.4.1"
 TranscodingStreams = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XAM"
 uuid = "d759349c-bcba-11e9-07c2-5b90f8f05f7c"
-version = "0.4.2"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Ben J. Ward <ward9250@gmail.com>", "Ciarán O'Mara <Ciaran.OMara@utas.edu.au>"]
+version = "0.4.2"
 
 [deps]
 Automa = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"

--- a/docs/src/man/hts-files.md
+++ b/docs/src/man/hts-files.md
@@ -293,8 +293,16 @@ To make a BAM Writer is slightly different, as you need to use a specific stream
 julia> using BGZFLib
 
 julia> bamw = BAM.Writer(BGZFLib.BGZFWriter(open("my-data.bam", "w")))
-BAM.Writer(BGZFLib.BGZFWriter{BufferIO.BufWriter{IOStream}}())
+BAM.Writer(BGZFWriter{BufferIO.BufWriter{IOStream}}())
+```
 
+BGZFStream is also supported for backward compatibility:
+
+```
+julia> using BGZFStreams
+
+julia> bamw = BAM.Writer(BGZFStream(open("my-data.bam", "w"), "w"))
+BAM.Writer(BGZFStreams.BGZFStream{IOStream}(<mode=write>))
 ```
 
 Once you have a BAM or SAM writer, you can use the `write` method to write `BAM.Record`s or `SAM.Record`s to file:

--- a/docs/src/man/hts-files.md
+++ b/docs/src/man/hts-files.md
@@ -287,13 +287,13 @@ SAM.Writer(IOStream(<file my-data.sam>))
 
 ```
 
-To make a BAM Writer is slightly different, as you need to use a specific stream type from the [https://github.com/BioJulia/BGZFStreams.jl](https://github.com/BioJulia/BGZFStreams.jl) package:
+To make a BAM Writer is slightly different, as you need to use a specific stream type from the [https://github.com/BioJulia/BGZFLib.jl](https://github.com/BioJulia/BGZFLib.jl) package:
 
 ```julia
-julia> using BGZFStreams
+julia> using BGZFLib
 
-julia> bamw = BAM.Writer(BGZFStream(open("my-data.bam", "w"), "w"))
-BAM.Writer(BGZFStreams.BGZFStream{IOStream}(<mode=write>))
+julia> bamw = BAM.Writer(BGZFLib.BGZFWriter(open("my-data.bam", "w")))
+BAM.Writer(BGZFLib.BGZFWriter{BufferIO.BufWriter{IOStream}}())
 
 ```
 

--- a/ext/BGZFStreamsExt.jl
+++ b/ext/BGZFStreamsExt.jl
@@ -1,0 +1,33 @@
+module BGZFStreamsExt
+
+using XAM
+using BGZFStreams
+
+import XAM.BAM: write_header
+
+function write_header(stream::BGZFStreams.BGZFStream, header, refseqnames, refseqlens)
+    @assert length(refseqnames) == length(refseqlens) "Lengths of refseq names and lengths must match."
+    n = 0
+
+    # magic bytes
+    n += write(stream, "BAM\1")
+
+    # SAM header
+    buf = IOBuffer()
+    l = write(SAM.Writer(buf), header)
+    n += write(stream, Int32(l))
+    n += write(stream, take!(buf))
+
+    # reference sequences
+    n += write(stream, Int32(length(refseqnames)))
+    for (seqname, seqlen) in zip(refseqnames, refseqlens)
+        namelen = length(seqname)
+        n += write(stream, Int32(namelen + 1))
+        n += write(stream, seqname, '\0')
+        n += write(stream, Int32(seqlen))
+    end
+
+    return n
+end
+
+end

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -18,6 +18,13 @@ import BioGenerics: isfilled, header
 
 import GenomicFeatures: eachoverlap
 
+# Indexes.Chunk.start/stop are BGZFStreams.VirtualOffset (a 64-bit primitive type).
+# Convert to BGZFLib.VirtualOffset without importing BGZFStreams.
+@inline function _to_virtual_offset(vo)
+    u = reinterpret(UInt64, vo)
+    BGZFLib.VirtualOffset(u >> 16, u & 0xffff)
+end
+
 # BGZFLib uses the BufferIO interface (not Base.IO), so Base.read(io, ::Type{T})
 # for non-UInt8 primitives is not provided. These private helpers own both the
 # function name and the dispatch, avoiding type piracy.

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -75,7 +75,7 @@ end
 end
 
 @inline function store_le(
-        io::BGZFLib.BGZFWriter,
+        io::Union{BGZFLib.BGZFWriter, BGZFLib.SyncBGZFWriter},
         x::T
     ) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
     x = htol(x)
@@ -90,7 +90,7 @@ end
     end
 end
 
-@noinline function store_le_slowpath(io::BGZFLib.BGZFWriter, x::T) where T
+@noinline function store_le_slowpath(io::Union{BGZFLib.BGZFWriter, BGZFLib.SyncBGZFWriter}, x::T) where T
     BufferIO.grow_buffer(io)
     buffer = BufferIO.get_buffer(io)
     # BGZFLib documents that grow_buffer will do a shallow flush,

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -17,33 +17,21 @@ import BioGenerics: isfilled, header
 
 import GenomicFeatures: eachoverlap
 
-# BGZFLib uses the BufferIO interface (not Base.IO), so Julia's generic
-# read(io, T) / write(io, T) for primitives don't dispatch. Add the minimal
-# overloads needed by BAM header reading/writing.
+# BGZFLib uses the BufferIO interface (not Base.IO), so Base.read(io, ::Type{T})
+# for non-UInt8 primitives is not provided. These private helpers own both the
+# function name and the dispatch, avoiding type piracy.
 
-Base.read(io::BGZFLib.BGZFReader, nb::Integer) =
-    (v = Vector{UInt8}(undef, nb); read!(io, v); v)
-
-function Base.read(io::BGZFLib.BGZFReader, ::Type{T}) where T<:Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+@inline function _bam_read(io::BGZFLib.BGZFReader, ::Type{T}) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
     ref = Ref{T}()
     GC.@preserve ref unsafe_read(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
     return ltoh(ref[])
 end
 
-function Base.write(io::BGZFLib.BGZFWriter, x::T) where T<:Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+@inline function _bam_write(io, x::T) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
     v = htol(x)
     ref = Ref(v)
     GC.@preserve ref return unsafe_write(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
 end
-
-Base.write(io::BGZFLib.BGZFWriter, v::AbstractVector{UInt8}) =
-    unsafe_write(io, pointer(v), UInt(length(v)))
-
-Base.write(io::BGZFLib.BGZFWriter, s::AbstractString) =
-    unsafe_write(io, pointer(s), UInt(ncodeunits(s)))
-
-Base.write(io::BGZFLib.BGZFWriter, c::Char) = write(io, UInt8(c))
-
 
 include("bai.jl")
 include("auxdata.jl")

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -9,13 +9,40 @@ using XAM.SAM
 import ..XAM: flags, XAMRecord, XAMReader, XAMWriter,
 	ismapped, isprimaryalignment, ispositivestrand, isnextmapped #TODO: Deprecate import of flag queries. These were imported to preseve existing API.
 
-import BGZFStreams
+import BGZFLib
 import BioAlignments
 import Indexes
 import BioSequences
 import BioGenerics: isfilled, header
 
 import GenomicFeatures: eachoverlap
+
+# BGZFLib uses the BufferIO interface (not Base.IO), so Julia's generic
+# read(io, T) / write(io, T) for primitives don't dispatch. Add the minimal
+# overloads needed by BAM header reading/writing.
+
+Base.read(io::BGZFLib.BGZFReader, nb::Integer) =
+    (v = Vector{UInt8}(undef, nb); read!(io, v); v)
+
+function Base.read(io::BGZFLib.BGZFReader, ::Type{T}) where T<:Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+    ref = Ref{T}()
+    GC.@preserve ref unsafe_read(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
+    return ltoh(ref[])
+end
+
+function Base.write(io::BGZFLib.BGZFWriter, x::T) where T<:Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+    v = htol(x)
+    ref = Ref(v)
+    GC.@preserve ref return unsafe_write(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
+end
+
+Base.write(io::BGZFLib.BGZFWriter, v::AbstractVector{UInt8}) =
+    unsafe_write(io, pointer(v), UInt(length(v)))
+
+Base.write(io::BGZFLib.BGZFWriter, s::AbstractString) =
+    unsafe_write(io, pointer(s), UInt(ncodeunits(s)))
+
+Base.write(io::BGZFLib.BGZFWriter, c::Char) = write(io, UInt8(c))
 
 
 include("bai.jl")

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -10,6 +10,7 @@ import ..XAM: flags, XAMRecord, XAMReader, XAMWriter,
 	ismapped, isprimaryalignment, ispositivestrand, isnextmapped #TODO: Deprecate import of flag queries. These were imported to preseve existing API.
 
 import BGZFLib
+import MemoryViews
 import BioAlignments
 import Indexes
 import BioSequences
@@ -23,7 +24,7 @@ import GenomicFeatures: eachoverlap
 
 @inline function _bam_read(io::BGZFLib.BGZFReader, ::Type{T}) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
     ref = Ref{T}()
-    GC.@preserve ref unsafe_read(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
+    GC.@preserve ref BGZFLib.BufferIO.read_all!(io, MemoryViews.MemoryView(unsafe_wrap(Array, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), sizeof(T))))
     return ltoh(ref[])
 end
 

--- a/src/bam/bam.jl
+++ b/src/bam/bam.jl
@@ -15,6 +15,7 @@ import BioAlignments
 import Indexes
 import BioSequences
 import BioGenerics: isfilled, header
+import BufferIO
 
 import GenomicFeatures: eachoverlap
 
@@ -25,21 +26,85 @@ import GenomicFeatures: eachoverlap
     BGZFLib.VirtualOffset(u >> 16, u & 0xffff)
 end
 
-# BGZFLib uses the BufferIO interface (not Base.IO), so Base.read(io, ::Type{T})
-# for non-UInt8 primitives is not provided. These private helpers own both the
-# function name and the dispatch, avoiding type piracy.
-
-@inline function _bam_read(io::BGZFLib.BGZFReader, ::Type{T}) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
-    ref = Ref{T}()
-    GC.@preserve ref BGZFLib.BufferIO.read_all!(io, MemoryViews.MemoryView(unsafe_wrap(Array, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), sizeof(T))))
-    return ltoh(ref[])
+@inline function load_le(
+            io::BufferIO.AbstractBufReader,
+            ::Type{T}
+    ) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+    # Fast path: Buffer has the data immediately available
+    buffer = BufferIO.get_buffer(io)
+    return if length(buffer) >= sizeof(T)
+        value = GC.@preserve buffer htol(unsafe_load(Ptr{T}(pointer(buffer))))
+        @inbounds BufferIO.consume(io, sizeof(T))
+        value
+    else
+        load_le_slowpath(io, T)
+    end
 end
 
-@inline function _bam_write(io, x::T) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
-    v = htol(x)
-    ref = Ref(v)
-    GC.@preserve ref return unsafe_write(io, Ptr{UInt8}(Base.unsafe_convert(Ptr{T}, ref)), UInt(sizeof(T)))
+@noinline function load_le_slowpath(io::BufferIO.AbstractBufReader, T)
+    # Second fastest path: A single fill_buffer (called via get_nonempty_buffer)
+    # provides enough data, and then we load it immediately
+    buffer = BufferIO.get_nonempty_buffer(io)
+    sz = sizeof(T)
+    buffer === nothing && throw(EOFError())
+    if length(buffer) >= sz
+        value = GC.@preserve buffer htol(unsafe_load(Ptr{T}(pointer(buffer))))
+        @inbounds BufferIO.consume(io, sizeof(T))
+        return value
+    end
+
+    # Very unlikely path: The T does not fit in the buffer of the IO, so
+    # We need to store a temporary buffer.
+    memory = MemoryViews.MemoryView(Memory{UInt8}(undef, sizeof(T)))
+    remaining = memory
+    while true
+        buffer = @inbounds buffer[1:min(length(buffer), length(remaining))]
+        @inbounds copyto!(remaining, buffer)
+        @inbounds BufferIO.consume(io, length(buffer))
+        remaining = @inbounds remaining[length(buffer) + 1 : end]
+        if isempty(remaining)
+            value = GC.@preserve memory htol(unsafe_load(Ptr{T}(pointer(memory))))
+            return value
+        end
+        buffer = let
+            b = BufferIO.get_nonempty_buffer(io)
+            b === nothing && throw(EOFError())
+            b
+        end
+    end
 end
+
+@inline function store_le(
+        io::BGZFLib.BGZFWriter,
+        x::T
+    ) where T <: Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Float32,Float64}
+    x = htol(x)
+    # Fast path: Buffer already has room to store the T
+    buffer = BufferIO.get_buffer(io)
+    if length(buffer) >= sizeof(T)
+        GC.@preserve buffer unsafe_store!(Ptr{T}(pointer(buffer)), x)
+        @inbounds BufferIO.consume(io, sizeof(T))
+        return nothing
+    else
+        store_le_slowpath(io, x)
+    end
+end
+
+@noinline function store_le_slowpath(io::BGZFLib.BGZFWriter, x::T) where T
+    BufferIO.grow_buffer(io)
+    buffer = BufferIO.get_buffer(io)
+    # BGZFLib documents that grow_buffer will do a shallow flush,
+    # and that the buffer size is 2^16 bytes.
+    # Some bytes are used for overhead, but this means we can guarantee around 2^16
+    # bytes are available now.
+    if length(buffer) < sizeof(T)
+        error("Invalid BGZF implementation, too small buffer size after grow_buffer is called")
+    end
+    GC.@preserve buffer unsafe_store!(Ptr{T}(pointer(buffer)), x)
+    @inbounds BufferIO.consume(io, sizeof(T))
+    return nothing
+end
+
 
 include("bai.jl")
 include("auxdata.jl")

--- a/src/bam/overlap.jl
+++ b/src/bam/overlap.jl
@@ -66,12 +66,15 @@ function Base.iterate(iter::OverlapIterator, state)
     while state.chunkid ≤ lastindex(state.chunks)
         chunk = state.chunks[state.chunkid]
         while BGZFLib.virtual_position(iter.reader.stream) < _to_virtual_offset(chunk.stop)
+            
+            # FIXME: This is a bit of a hack, should be fixed in the future, BioGenerics uses this pattern
             try
                 read!(iter.reader, state.record)
             catch ex
                 ex isa EOFError && break
                 rethrow()
             end
+        
             c = compare_intervals(state.record, (state.refindex, iter.interval))
             if c == 0  # overlapping
                 return copy(state.record), state
@@ -80,6 +83,7 @@ function Base.iterate(iter::OverlapIterator, state)
                 # no more overlapping records in this chunk since records are sorted
                 break
             end
+            
         end
         state.chunkid += 1
         if state.chunkid ≤ lastindex(state.chunks)

--- a/src/bam/overlap.jl
+++ b/src/bam/overlap.jl
@@ -65,7 +65,7 @@ end
 function Base.iterate(iter::OverlapIterator, state)
     while state.chunkid ≤ lastindex(state.chunks)
         chunk = state.chunks[state.chunkid]
-        while BGZFStreams.virtualoffset(iter.reader.stream) < chunk.stop
+        while BGZFLib.virtual_position(iter.reader.stream) < chunk.stop
             read!(iter.reader, state.record)
             c = compare_intervals(state.record, (state.refindex, iter.interval))
             if c == 0  # overlapping

--- a/src/bam/overlap.jl
+++ b/src/bam/overlap.jl
@@ -58,15 +58,20 @@ function Base.iterate(iter::OverlapIterator)
         return nothing
     end
     state = OverlapIteratorState(refindex, chunks, 1, Record())
-    seek(iter.reader, state.chunks[state.chunkid].start)
+    seek(iter.reader, _to_virtual_offset(state.chunks[state.chunkid].start))
     return iterate(iter, state)
 end
 
 function Base.iterate(iter::OverlapIterator, state)
     while state.chunkid ≤ lastindex(state.chunks)
         chunk = state.chunks[state.chunkid]
-        while BGZFLib.virtual_position(iter.reader.stream) < chunk.stop
-            read!(iter.reader, state.record)
+        while BGZFLib.virtual_position(iter.reader.stream) < _to_virtual_offset(chunk.stop)
+            try
+                read!(iter.reader, state.record)
+            catch ex
+                ex isa EOFError && break
+                rethrow()
+            end
             c = compare_intervals(state.record, (state.refindex, iter.interval))
             if c == 0  # overlapping
                 return copy(state.record), state
@@ -78,7 +83,7 @@ function Base.iterate(iter::OverlapIterator, state)
         end
         state.chunkid += 1
         if state.chunkid ≤ lastindex(state.chunks)
-            seek(iter.reader, state.chunks[state.chunkid].start)
+            seek(iter.reader, _to_virtual_offset(state.chunks[state.chunkid].start))
         end
     end
     # no more overlapping records

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -64,7 +64,7 @@ function Base.seek(reader::Reader, voffset::BGZFLib.VirtualOffset)
 end
 
 function Base.seekstart(reader::Reader)
-    seek(reader.stream, reader.start_offset)
+    BGZFLib.virtual_seek(reader.stream, reader.start_offset)
 end
 
 function Base.iterate(reader::Reader, nextone = Record())
@@ -124,15 +124,18 @@ init_bam_index(index::Nothing) = nothing
 init_bam_index(index) = error("unrecognizable index argument")
 
 function _read!(reader::Reader, record)
-    unsafe_read(
+    # BufferIO.unsafe_read returns a byte count (unlike Base.IO which throws EOFError).
+    # Check explicitly so the overlap iterator's virtual_position check stays bounded.
+    n = unsafe_read(
         reader.stream,
         pointer_from_objref(record),
-        UInt64(FIXED_FIELDS_BYTES))
+        UInt(FIXED_FIELDS_BYTES))
+    n < FIXED_FIELDS_BYTES && throw(EOFError())
     dsize = data_size(record)
     if length(record.data) < dsize
         resize!(record.data, dsize)
     end
-    unsafe_read(reader.stream, pointer(record.data), UInt64(dsize))
+    unsafe_read(reader.stream, pointer(record.data), UInt(dsize))
     record.reader = reader
     return record
 end

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -87,18 +87,18 @@ function init_bam_reader(input::BGZFLib.BGZFReader)
     end
 
     # SAM header
-    textlen = _bam_read(input, Int32)
+    textlen = load_le(input, Int32)
     samreader = SAM.Reader(IOBuffer(read(input, textlen)))
 
     # reference sequences
-    n_refs = _bam_read(input, Int32)
+    n_refs = load_le(input, Int32)
     refseqnames = Vector{String}(undef, n_refs)
     refseqlens = Vector{Int}(undef, n_refs)
     @inbounds for i in 1:n_refs
-        namelen = _bam_read(input, Int32)
+        namelen = load_le(input, Int32)
         data = read(input, namelen)
         seqname = unsafe_string(pointer(data))
-        seqlen = _bam_read(input, Int32)
+        seqlen = load_le(input, Int32)
         refseqnames[i] = seqname
         refseqlens[i] = seqlen
     end

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -135,7 +135,8 @@ function _read!(reader::Reader, record)
     if length(record.data) < dsize
         resize!(record.data, dsize)
     end
-    unsafe_read(reader.stream, pointer(record.data), UInt(dsize))
+    n = unsafe_read(reader.stream, pointer(record.data), UInt(dsize))
+    n < dsize && throw(EOFError())
     record.reader = reader
     return record
 end

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -11,9 +11,9 @@ Create a data reader of the BAM file format.
 * `index=nothing`: filepath to a random access index (currently *bai* is supported) or BAI object
 """
 mutable struct Reader{T} <: XAMReader
-    stream::BGZFStreams.BGZFStream{T}
+    stream::BGZFLib.BGZFReader{T}
     header::SAM.Header
-    start_offset::BGZFStreams.VirtualOffset
+    start_offset::BGZFLib.VirtualOffset
     refseqnames::Vector{String}
     refseqlens::Vector{Int}
     index::Union{Nothing, BAI}
@@ -59,8 +59,8 @@ function header(reader::Reader; fillSQ::Bool=false)::SAM.Header
     return header
 end
 
-function Base.seek(reader::Reader, voffset::BGZFStreams.VirtualOffset)
-    seek(reader.stream, voffset)
+function Base.seek(reader::Reader, voffset::BGZFLib.VirtualOffset)
+    BGZFLib.virtual_seek(reader.stream, voffset)
 end
 
 function Base.seekstart(reader::Reader)
@@ -75,7 +75,7 @@ function Base.iterate(reader::Reader, nextone = Record())
 end
 
 # Initialize a BAM reader by reading the header section.
-function init_bam_reader(input::BGZFStreams.BGZFStream)
+function init_bam_reader(input::BGZFLib.BGZFReader)
     # magic bytes
     B = read(input, UInt8)
     A = read(input, UInt8)
@@ -103,9 +103,7 @@ function init_bam_reader(input::BGZFStreams.BGZFStream)
         refseqlens[i] = seqlen
     end
 
-    voffset = isa(input.io, Base.AbstractPipe) ?
-        BGZFStreams.VirtualOffset(0, 0) :
-        BGZFStreams.virtualoffset(input)
+    voffset = BGZFLib.virtual_position(input)
 
     return Reader(
         input,
@@ -117,7 +115,7 @@ function init_bam_reader(input::BGZFStreams.BGZFStream)
 end
 
 function init_bam_reader(input::IO)
-    return init_bam_reader(BGZFStreams.BGZFStream(input))
+    return init_bam_reader(BGZFLib.BGZFReader(input))
 end
 
 init_bam_index(index::AbstractString) = BAI(index)
@@ -129,12 +127,12 @@ function _read!(reader::Reader, record)
     unsafe_read(
         reader.stream,
         pointer_from_objref(record),
-        FIXED_FIELDS_BYTES)
+        UInt64(FIXED_FIELDS_BYTES))
     dsize = data_size(record)
     if length(record.data) < dsize
         resize!(record.data, dsize)
     end
-    unsafe_read(reader.stream, pointer(record.data), dsize)
+    unsafe_read(reader.stream, pointer(record.data), UInt64(dsize))
     record.reader = reader
     return record
 end

--- a/src/bam/reader.jl
+++ b/src/bam/reader.jl
@@ -87,18 +87,18 @@ function init_bam_reader(input::BGZFLib.BGZFReader)
     end
 
     # SAM header
-    textlen = read(input, Int32)
+    textlen = _bam_read(input, Int32)
     samreader = SAM.Reader(IOBuffer(read(input, textlen)))
 
     # reference sequences
-    n_refs = read(input, Int32)
+    n_refs = _bam_read(input, Int32)
     refseqnames = Vector{String}(undef, n_refs)
     refseqlens = Vector{Int}(undef, n_refs)
     @inbounds for i in 1:n_refs
-        namelen = read(input, Int32)
+        namelen = _bam_read(input, Int32)
         data = read(input, namelen)
         seqname = unsafe_string(pointer(data))
-        seqlen = read(input, Int32)
+        seqlen = _bam_read(input, Int32)
         refseqnames[i] = seqname
         refseqlens[i] = seqlen
     end

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -469,31 +469,6 @@ function sequence(record::Record)
     return BioSequences.LongDNA{4}(data, UInt(seqlen))
 end
 
-"""
-    sequence!(buf::BioSequences.LongDNA{4}, record::Record)
-
-Fill `buf` in-place with the sequence of `record`. Data is copied into `buf`'s
-internal storage, so the result is independent of `record`.
-"""
-function sequence!(buf::BioSequences.LongDNA{4}, record::Record)
-    checkfilled(record)
-    seqlen = seqlength(record)
-    resize!(buf, seqlen)
-    seqlen == 0 && return buf
-    n_words = cld(seqlen, 16)
-    seq_data = record.data
-    buf_data = buf.data
-    offset = seqname_length(record) + n_cigar_op(record, false) * 4 + 1
-    GC.@preserve seq_data buf_data begin
-        src = Ptr{UInt64}(pointer(seq_data, offset))
-        for i in 1:n_words
-            x = unsafe_load(src, i)
-            @inbounds buf_data[i] = (x & 0x0f0f0f0f0f0f0f0f) << 4 | (x & 0xf0f0f0f0f0f0f0f0) >> 4
-        end
-    end
-    return buf
-end
-
 function hassequence(record::Record)
     return isfilled(record)
 end
@@ -522,19 +497,6 @@ function quality(record::Record)
     seqlen = seqlength(record)
     offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
     return record.data[(1+offset):(seqlen+offset)]
-end
-
-"""
-    quality_view(record::Record)
-
-Get a view into the base quality of `record`.
-Warning : The view is tied to the `record` and can be invalidated by a subsequent read!(reader, record) call.
-"""
-function quality_view(record::Record)
-    checkfilled(record)
-    seqlen = seqlength(record)
-    offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
-    return @view record.data[(1+offset):(seqlen+offset)]
 end
 
 function hasquality(record::Record)

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -469,6 +469,32 @@ function sequence(record::Record)
     return BioSequences.LongDNA{4}(data, UInt(seqlen))
 end
 
+# Fill `buf` in-place with the sequence of `record`, reusing its internal
+# Vector{UInt64} storage. Grows if needed, never shrinks.
+# Valid until the next sequence!(buf, ...) call.
+function sequence!(buf::BioSequences.LongDNA{4}, record::Record)
+    checkfilled(record)
+    seqlen = seqlength(record)
+    if seqlen == 0
+        buf.len = UInt(0)
+        return buf
+    end
+    n_words = cld(seqlen, 16)
+    length(buf.data) < n_words && resize!(buf.data, n_words)
+    buf.len = UInt(seqlen)
+    seq_data = record.data
+    buf_data = buf.data
+    offset = seqname_length(record) + n_cigar_op(record, false) * 4 + 1
+    GC.@preserve seq_data buf_data begin
+        src = Ptr{UInt64}(pointer(seq_data, offset))
+        for i in 1:n_words
+            x = unsafe_load(src, i)
+            @inbounds buf_data[i] = (x & 0x0f0f0f0f0f0f0f0f) << 4 | (x & 0xf0f0f0f0f0f0f0f0) >> 4
+        end
+    end
+    return buf
+end
+
 function hassequence(record::Record)
     return isfilled(record)
 end
@@ -497,6 +523,15 @@ function quality(record::Record)
     seqlen = seqlength(record)
     offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
     return record.data[(1+offset):(seqlen+offset)]
+end
+
+# Like quality(), but returns a view into record.data — no allocation.
+# The view is only valid until the next read!(reader, record) call.
+function quality_view(record::Record)
+    checkfilled(record)
+    seqlen = seqlength(record)
+    offset = seqname_length(record) + n_cigar_op(record, false) * 4 + cld(seqlen, 2)
+    return @view record.data[(1+offset):(seqlen+offset)]
 end
 
 function hasquality(record::Record)

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -469,9 +469,12 @@ function sequence(record::Record)
     return BioSequences.LongDNA{4}(data, UInt(seqlen))
 end
 
-# Fill `buf` in-place with the sequence of `record`, reusing its internal
-# Vector{UInt64} storage. Grows if needed, never shrinks.
-# Valid until the next sequence!(buf, ...) call.
+"""
+    sequence!(buf::BioSequences.LongDNA{4}, record::Record)
+
+Fill `buf` in-place with the sequence of `record`. Data is copied into `buf`'s
+internal storage, so the result is independent of `record`.
+"""
 function sequence!(buf::BioSequences.LongDNA{4}, record::Record)
     checkfilled(record)
     seqlen = seqlength(record)
@@ -521,8 +524,12 @@ function quality(record::Record)
     return record.data[(1+offset):(seqlen+offset)]
 end
 
-# Like quality(), but returns a view into record.data — no allocation.
-# The view is only valid until the next read!(reader, record) call.
+"""
+    quality_view(record::Record)
+
+Get a view into the base quality of `record`.
+Warning : The view is tied to the `record` and can be invalidated by a subsequent read!(reader, record) call.
+"""
 function quality_view(record::Record)
     checkfilled(record)
     seqlen = seqlength(record)

--- a/src/bam/record.jl
+++ b/src/bam/record.jl
@@ -475,13 +475,9 @@ end
 function sequence!(buf::BioSequences.LongDNA{4}, record::Record)
     checkfilled(record)
     seqlen = seqlength(record)
-    if seqlen == 0
-        buf.len = UInt(0)
-        return buf
-    end
+    resize!(buf, seqlen)
+    seqlen == 0 && return buf
     n_words = cld(seqlen, 16)
-    length(buf.data) < n_words && resize!(buf.data, n_words)
-    buf.len = UInt(seqlen)
     seq_data = record.data
     buf_data = buf.data
     offset = seqname_length(record) + n_cigar_op(record, false) * 4 + 1

--- a/src/bam/writer.jl
+++ b/src/bam/writer.jl
@@ -2,7 +2,7 @@
 # ==========
 
 """
-    BAM.Writer(output::BGZFStream, header::SAM.Header)
+    BAM.Writer(output::BGZFWriter, header::SAM.Header)
 
 Create a data writer of the BAM file format.
 
@@ -11,10 +11,10 @@ Create a data writer of the BAM file format.
 * `header`: SAM header object
 """
 mutable struct Writer <: XAMWriter
-    stream::BGZFStreams.BGZFStream
+    stream::BGZFLib.BGZFWriter
 end
 
-function Writer(stream::BGZFStreams.BGZFStream, header::SAM.Header)
+function Writer(stream::BGZFLib.BGZFWriter, header::SAM.Header)
     refseqnames = String[]
     refseqlens = Int[]
     for metainfo in findall(header, "SQ")
@@ -31,8 +31,8 @@ end
 
 function Base.write(writer::Writer, record::Record)
     n = 0
-    n += unsafe_write(writer.stream, pointer_from_objref(record), FIXED_FIELDS_BYTES)
-    n += unsafe_write(writer.stream, pointer(record.data), data_size(record))
+    n += unsafe_write(writer.stream, pointer_from_objref(record), UInt64(FIXED_FIELDS_BYTES))
+    n += unsafe_write(writer.stream, pointer(record.data), UInt64(data_size(record)))
     return n
 end
 

--- a/src/bam/writer.jl
+++ b/src/bam/writer.jl
@@ -46,16 +46,16 @@ function write_header(stream, header, refseqnames, refseqlens)
     # SAM header
     buf = IOBuffer()
     l = write(SAM.Writer(buf), header)
-    n += write(stream, Int32(l))
+    n += _bam_write(stream, Int32(l))
     n += write(stream, take!(buf))
 
     # reference sequences
-    n += write(stream, Int32(length(refseqnames)))
+    n += _bam_write(stream, Int32(length(refseqnames)))
     for (seqname, seqlen) in zip(refseqnames, refseqlens)
         namelen = length(seqname)
-        n += write(stream, Int32(namelen + 1))
+        n += _bam_write(stream, Int32(namelen + 1))
         n += write(stream, seqname, '\0')
-        n += write(stream, Int32(seqlen))
+        n += _bam_write(stream, Int32(seqlen))
     end
 
     return n

--- a/src/bam/writer.jl
+++ b/src/bam/writer.jl
@@ -2,7 +2,7 @@
 # ==========
 
 """
-    BAM.Writer(output::BGZFWriter, header::SAM.Header)
+    BAM.Writer(output::T, header::SAM.Header)
 
 Create a data writer of the BAM file format.
 
@@ -10,11 +10,11 @@ Create a data writer of the BAM file format.
 * `output`: data sink
 * `header`: SAM header object
 """
-mutable struct Writer <: XAMWriter
-    stream::BGZFLib.BGZFWriter
+mutable struct Writer{T} <: XAMWriter
+    stream::T
 end
 
-function Writer(stream::BGZFLib.BGZFWriter, header::SAM.Header)
+function Writer(stream::T, header::SAM.Header) where T
     refseqnames = String[]
     refseqlens = Int[]
     for metainfo in findall(header, "SQ")
@@ -38,25 +38,24 @@ end
 
 function write_header(stream, header, refseqnames, refseqlens)
     @assert length(refseqnames) == length(refseqlens) "Lengths of refseq names and lengths must match."
-    n = 0
-
+    
     # magic bytes
-    n += write(stream, "BAM\1")
+    write(stream, "BAM\1")
 
     # SAM header
     buf = IOBuffer()
     l = write(SAM.Writer(buf), header)
-    n += _bam_write(stream, Int32(l))
-    n += write(stream, take!(buf))
+    store_le(stream, Int32(l))
+    write(stream, take!(buf))
 
     # reference sequences
-    n += _bam_write(stream, Int32(length(refseqnames)))
+    store_le(stream, Int32(length(refseqnames)))
     for (seqname, seqlen) in zip(refseqnames, refseqlens)
         namelen = length(seqname)
-        n += _bam_write(stream, Int32(namelen + 1))
-        n += write(stream, seqname, '\0')
-        n += _bam_write(stream, Int32(seqlen))
+        store_le(stream, Int32(namelen + 1))
+        write(stream, seqname, '\0')
+        store_le(stream, Int32(seqlen))
     end
 
-    return n
+    return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using BGZFStreams
 import BioAlignments: Alignment, AlignmentAnchor, OP_START, OP_MATCH, OP_DELETE
 import BGZFLib: BGZFReader, BGZFWriter, EOF_BLOCK
 import BioGenerics.Exceptions: MissingFieldException
-import BioSequences: @dna_str, @aa_str, LongDNA
+import BioSequences: @dna_str, @aa_str
 
 
 # Generate a random range within `range`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using XAM
 import BioAlignments: Alignment, AlignmentAnchor, OP_START, OP_MATCH, OP_DELETE
 import BGZFLib: BGZFReader, BGZFWriter
 import BioGenerics.Exceptions: MissingFieldException
-import BioSequences: @dna_str, @aa_str
+import BioSequences: @dna_str, @aa_str, LongDNA
 
 
 # Generate a random range within `range`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using BioGenerics
 using FormatSpecimens
 using GenomicFeatures
 using XAM
+using BGZFStreams
 
 import BioAlignments: Alignment, AlignmentAnchor, OP_START, OP_MATCH, OP_DELETE
 import BGZFLib: BGZFReader, BGZFWriter, EOF_BLOCK

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using GenomicFeatures
 using XAM
 
 import BioAlignments: Alignment, AlignmentAnchor, OP_START, OP_MATCH, OP_DELETE
-import BGZFLib: BGZFReader, BGZFWriter
+import BGZFLib: BGZFReader, BGZFWriter, EOF_BLOCK
 import BioGenerics.Exceptions: MissingFieldException
 import BioSequences: @dna_str, @aa_str, LongDNA
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using GenomicFeatures
 using XAM
 
 import BioAlignments: Alignment, AlignmentAnchor, OP_START, OP_MATCH, OP_DELETE
-import BGZFStreams: BGZFStream
+import BGZFLib: BGZFReader, BGZFWriter
 import BioGenerics.Exceptions: MissingFieldException
 import BioSequences: @dna_str, @aa_str
 

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -199,7 +199,7 @@
 
                 header_original = header(reader)
 
-                writer = BAM.Writer(BGZFStream(path, "w"), BAM.header(reader, fillSQ=isempty(findall(header(reader), "SQ"))))
+                writer = BAM.Writer(BGZFWriter(open(path, "w")), BAM.header(reader, fillSQ=isempty(findall(header(reader), "SQ"))))
 
                 records = BAM.Record[]
                 for record in reader
@@ -212,8 +212,8 @@
 
                 # Check that EOF_BLOCK gets written.
                 nbytes = filesize(path)
-                @test BAM.BGZFStreams.EOF_BLOCK == open(path) do io
-                    seek(io, nbytes - length(BAM.BGZFStreams.EOF_BLOCK))
+                @test BGZFLib.EOF_BLOCK == open(path) do io
+                    seek(io, nbytes - length(BGZFLib.EOF_BLOCK))
                     read(io)
                 end
 

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -228,6 +228,48 @@
         end
     end
 
+    @testset "Round trip, BGZFStreams" begin
+        for specimen in list_valid_specimens("BAM")
+            filepath = joinpath(bamdir, filename(specimen))
+            mktemp() do path, _
+                # copy
+                if hastags(specimen) && in("bai", tags(specimen))
+                    reader = open(BAM.Reader, filepath, index=filepath * ".bai")
+                else
+                    reader = open(BAM.Reader, filepath)
+                end
+
+                header_original = header(reader)
+
+                writer = BAM.Writer(BGZFStreams.BGZFStream(path, "w"), BAM.header(reader, fillSQ=isempty(findall(header(reader), "SQ"))))
+
+                records = BAM.Record[]
+                for record in reader
+                    push!(records, record)
+                    write(writer, record)
+                end
+                close(reader)
+                close(writer)
+
+
+                # Check that EOF_BLOCK gets written.
+                nbytes = filesize(path)
+                @test EOF_BLOCK == open(path) do io
+                    seek(io, nbytes - length(EOF_BLOCK))
+                    read(io)
+                end
+
+                reader = open(BAM.Reader, path)
+
+                @test header(reader) == header_original
+                @test compare_records(collect(reader), records)
+
+                close(reader)
+
+            end
+        end
+    end
+
     @testset "In-Place-Reading Pattern" begin
 
         file_bam = joinpath(bamdir, "ce#5b.bam")

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -75,23 +75,7 @@
         @test BAM.seqlength(record) === 100
         @test BAM.hasquality(record)
         @test eltype(BAM.quality(record)) == UInt8
-        expected_quality = [Int(x) - 33 for x in "#############################@B?8B?BA@@DDBCDDCBC@CDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]
-        @test BAM.quality(record) == expected_quality
-        # quality_view returns a view (no allocation) that matches quality()
-        qv = BAM.quality_view(record)
-        @test qv == expected_quality
-        @test qv isa AbstractVector{UInt8}
-        @test parent(qv) === record.data
-
-        expected_seq = BAM.sequence(record)
-        # sequence! fills a buffer in-place and must match the allocating sequence()
-        buf = LongDNA{4}(undef, 0)
-        BAM.sequence!(buf, record)
-        @test buf == expected_seq
-        # calling again reuses the buffer (length stays the same, content identical)
-        BAM.sequence!(buf, record)
-        @test buf == expected_seq
-
+        @test BAM.quality(record) == [Int(x) - 33 for x in "#############################@B?8B?BA@@DDBCDDCBC@CDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]
         @test BAM.flags(record) === UInt16(16)
         @test BAM.cigar(record) == "27M1D73M"
         @test BAM.alignment(record) == Alignment([

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -228,8 +228,8 @@
 
                 # Check that EOF_BLOCK gets written.
                 nbytes = filesize(path)
-                @test BGZFLib.EOF_BLOCK == open(path) do io
-                    seek(io, nbytes - length(BGZFLib.EOF_BLOCK))
+                @test EOF_BLOCK == open(path) do io
+                    seek(io, nbytes - length(EOF_BLOCK))
                     read(io)
                 end
 

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -75,7 +75,23 @@
         @test BAM.seqlength(record) === 100
         @test BAM.hasquality(record)
         @test eltype(BAM.quality(record)) == UInt8
-        @test BAM.quality(record) == [Int(x) - 33 for x in "#############################@B?8B?BA@@DDBCDDCBC@CDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]
+        expected_quality = [Int(x) - 33 for x in "#############################@B?8B?BA@@DDBCDDCBC@CDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]
+        @test BAM.quality(record) == expected_quality
+        # quality_view returns a view (no allocation) that matches quality()
+        qv = BAM.quality_view(record)
+        @test qv == expected_quality
+        @test qv isa AbstractVector{UInt8}
+        @test parent(qv) === record.data
+
+        expected_seq = BAM.sequence(record)
+        # sequence! fills a buffer in-place and must match the allocating sequence()
+        buf = LongDNA{4}(undef, 0)
+        BAM.sequence!(buf, record)
+        @test buf == expected_seq
+        # calling again reuses the buffer (length stays the same, content identical)
+        BAM.sequence!(buf, record)
+        @test buf == expected_seq
+
         @test BAM.flags(record) === UInt16(16)
         @test BAM.cigar(record) == "27M1D73M"
         @test BAM.alignment(record) == Alignment([

--- a/test/test_bam.jl
+++ b/test/test_bam.jl
@@ -44,7 +44,7 @@
         reader = open(BAM.Reader, joinpath(bamdir, "ce#1.bam"))
         @test isa(reader, BAM.Reader)
         @test eltype(reader) === BAM.Record
-        @test startswith(repr(reader), "XAM.BAM.Reader{IOStream}:")
+        @test startswith(repr(reader), "XAM.BAM.Reader{")
 
         # header
         h = header(reader)


### PR DESCRIPTION
I had some time so I've tried to replace BGZFStreams the new libdefalte based BGZFLib. I used Claude for this but it was struggling quite a bit so I also had to contribute as well... The code look ok I think and all tests pass. There's maybe some rough edges (e.g. `_to_virtual_offset` should be a method in BGZFLib?) but maybe that can be tackled later on, using this PR as a base.

I also added to methods for allocation free sequence and quality extraction.

The performance are pretty good, computing the mean base quality on a 3.0G BAM file, 3x faster, same result :

Before :
>29.076704 seconds (2.61 M allocations: 180.409 MiB, 0.10% gc time)
>39.3092853294488

After : 
>10.851930 seconds (3.68 M allocations: 256.426 MiB, 0.31% gc time, 85932 lock conflicts)
>39.3092853294488