### PR TITLE
Fix and update flags documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Added conversion capability for SAM to BAM ([#63](https://github.com/BioJulia/XAM.jl/pull/63)).
+- Updated the documentation for the functions that query SAM/BAM flags.
 
 ## [0.4.2]
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ using Documenter, XAM
 makedocs(
     checkdocs = :all,
     linkcheck = true,
+    warnonly = true,
     format = Documenter.HTML(
         edit_link = "develop"
     ),

--- a/docs/src/man/api.md
+++ b/docs/src/man/api.md
@@ -36,3 +36,31 @@ private = false
 Modules = [XAM.BAM]
 public = false
 ```
+
+## Flags API
+The Flags API provides predicates to test properties of the XAM records encoded in the SAM/BAM flags. They can be used for both SAM and BAM records.
+
+```@docs
+XAM.ispaired(record::XAMRecord)
+XAM.isproperpair(record::XAMRecord)
+XAM.isunmapped(record::XAMRecord)
+XAM.ismapped(record::XAMRecord)
+XAM.isnextunmapped(record::XAMRecord)
+XAM.isnextmapped(record::XAMRecord)
+XAM.isreversecomplemented(record::XAMRecord)
+XAM.isforwardstrand(record::XAMRecord)
+XAM.ispositivestrand(record::XAMRecord)
+XAM.isreversestrand(record::XAMRecord)
+XAM.isnegativestrand(record::XAMRecord)
+XAM.isnextreversecomplemented(record::XAMRecord)
+XAM.isfirstsegment(record::XAMRecord)
+XAM.isread1(record::XAMRecord)
+XAM.islastsegment(record::XAMRecord)
+XAM.isread2(record::XAMRecord)
+XAM.issecondaryalignment(record::XAMRecord)
+XAM.isqcfail(record::XAMRecord)
+XAM.isduplicate(record::XAMRecord)
+XAM.issupplementaryalignment(record::XAMRecord)
+XAM.isprimaryalignment(record::XAMRecord)
+```
+

--- a/docs/src/man/hts-files.md
+++ b/docs/src/man/hts-files.md
@@ -110,13 +110,9 @@ In the above we can see there were 7 sequences in the reference: 5 chromosomes, 
 The `XAM` package supports the following accessors for `SAM.Record` types.
 
 ```@docs
-XAM.SAM.flags
-XAM.SAM.ismapped
-XAM.SAM.isprimaryalignment
 XAM.SAM.refname
 XAM.SAM.position
 XAM.SAM.rightposition
-XAM.SAM.isnextmapped
 XAM.SAM.nextrefname
 XAM.SAM.nextposition
 XAM.SAM.mappingquality
@@ -135,15 +131,11 @@ XAM.SAM.auxdata
 The `XAM` package supports the following accessors for `BAM.Record` types.
 
 ```@docs
-XAM.BAM.flags
-XAM.BAM.ismapped
-XAM.BAM.isprimaryalignment
 XAM.BAM.refid
 XAM.BAM.refname
 XAM.BAM.reflen
 XAM.BAM.position
 XAM.BAM.rightposition
-XAM.BAM.isnextmapped
 XAM.BAM.nextrefid
 XAM.BAM.nextrefname
 XAM.BAM.nextposition
@@ -157,6 +149,50 @@ XAM.BAM.sequence
 XAM.BAM.seqlength
 XAM.BAM.quality
 XAM.BAM.auxdata
+```
+
+## SAM and BAM Flags
+SAM and BAM records containt a FLAG field with bitwise flags. The bits are explained in the following table:
+
+| Decimal | Hex   | Description                                                        |
+|---------|-------|--------------------------------------------------------------------|
+| 1       | 0x1   | template having multiple segments in sequencing                    |
+| 2       | 0x2   | each segment properly aligned according to the aligner             |
+| 4       | 0x4   | segment unmapped                                                   |
+| 8       | 0x8   | next segment in the template unmapped                              |
+| 16      | 0x10  | SEQ being reverse complemented                                     |
+| 32      | 0x20  | SEQ of the next segment in the template being reverse complemented |
+| 64      | 0x40  | the first segment in the template                                  |
+| 128     | 0x80  | the last segment in the template                                   |
+| 256     | 0x100 | secondary alignment                                                |
+| 512     | 0x200 | not passing filters, such as platform/vendor quality controls      |
+| 1024    | 0x400 | PCR or optical duplicate                                           |
+| 2048    | 0x800 | supplementary alignment                                            |
+
+The `XAM` package provides the following predicates for both SAM and BAM records to query the tags:
+
+```@docs
+XAM.ispaired
+XAM.isproperpair
+XAM.isunmapped
+XAM.ismapped
+XAM.isnextunmapped
+XAM.isnextmapped
+XAM.isreversecomplemented
+XAM.isforwardstrand
+XAM.ispositivestrand
+XAM.isreversestrand
+XAM.isnegativestrand
+XAM.isnextreversecomplemented
+XAM.isfirstsegment
+XAM.isread1
+XAM.islastsegment
+XAM.isread2
+XAM.issecondaryalignment
+XAM.isqcfail
+XAM.isduplicate
+XAM.issupplementaryalignment
+XAM.isprimaryalignment
 ```
 
 ## Accessing auxiliary data

--- a/src/flags.jl
+++ b/src/flags.jl
@@ -112,18 +112,22 @@ function isnextmapped(record::XAMRecord)::Bool
 end
 
 """
-    isreverse(record::XAMRecord)::Bool
+    isreversecomplemented(record::XAMRecord)::Bool
 
 Query whether the `record.SEQ`uence is reverse complemented.
+
+Aliases: [`isreversestrand`](@ref), [`isnegativestrand`](@ref)
 """
 function isreversecomplemented(record::XAMRecord)::Bool
     return flags(record) & FLAG_REVERSE == FLAG_REVERSE
 end
 
 """
-    isforward(record::XAMRecord)::Bool
+    isforwardstrand(record::XAMRecord)::Bool
 
 Query whether the `record.SEQ`uence is mapped to the forward strand.
+
+Aliases: [`ispositivestrand`](@ref)
 """
 function isforwardstrand(record::XAMRecord)::Bool
     # return flags(record) & FLAG_REVERSE == 0
@@ -134,6 +138,8 @@ end
     ispositivestrand(record::XAMRecord)::Bool
 
 Query whether the `record.SEQ`uence is aligned to the positive strand.
+
+Aliases: [`isforwardstrand`](@ref)
 """
 function ispositivestrand(record::XAMRecord)::Bool
     return isforwardstrand(record)
@@ -143,15 +149,19 @@ end
     isreversestrand(record::XAMRecord)::Bool
 
 Query whether the `record.SEQ`uence is aligned to the reverse strand.
+
+Aliases: [`isreversecomplemented`](@ref), [`isnegativestrand`](@ref)
 """
 function isreversestrand(record::XAMRecord)::Bool
     return isreversecomplemented(record) # Note: this is an interpretation of FLAG_REVERSE.
 end
 
 """
-    ispositivestrand(record::XAMRecord)::Bool
+    isnegativestrand(record::XAMRecord)::Bool
 
 Query whether the `record.SEQ`uence is aligned to the negative strand.
+
+Aliases: [`isreversecomplemented`](@ref), [`isreversestrand`](@ref)
 """
 function isnegativestrand(record::XAMRecord)::Bool
     return isreversestrand(record)
@@ -170,6 +180,8 @@ end
     isfirstsegment(record::XAMRecord)::Bool
 
 Query whether the segemnt is first in the template.
+
+Aliases: [`isread1`](@ref)
 """
 function isfirstsegment(record::XAMRecord)::Bool
     return flags(record) & FLAG_FIRST_SEGMENT == FLAG_FIRST_SEGMENT
@@ -179,6 +191,8 @@ end
     isread1(record::XAMRecord)::Bool
 
 From a paired-end sequencing point of view, query whether the read is read1.
+
+Aliases: [`isfirstsegment`](@ref)
 """
 function isread1(record::XAMRecord)::Bool
     return isfirstsegment(record)
@@ -188,6 +202,8 @@ end
     islastsegment(record::XAMRecord)::Bool
 
 Query whether the segemnt is last in the template.
+
+Aliases: [`isread2`](@ref)
 """
 function islastsegment(record::XAMRecord)::Bool
     return flags(record) & FLAG_LAST_SEGMENT == FLAG_LAST_SEGMENT
@@ -197,6 +213,8 @@ end
     isread2(record::XAMRecord)::Bool
 
 From a paired-end sequencing point of view, query whether the read is read2.
+
+Aliases: [`islastsegment`](@ref)
 """
 function isread2(record::XAMRecord)::Bool
     return islastsegment(record)


### PR DESCRIPTION
# Fix and update the documentation for the functions that query the flag field

## Types of changes

No functional changes, only updates in the documentation.

- Add a section in the main documentation page for the functions in flags.jl. They already had docstrings, but they were not exposed in the web page, making it harder for people to know they exist. 
- A section for the `flags.jl` functions in the API page.
- A few of the docstrings in `flags.jl` where referring to old names of the functions that have since been changed.
- I'm not sure if I am running the doc generation incorrectly, but I get errors because the docs for some functions are duplicated (they're both in the main index page and in API) as well as some broken links to opencollective. I added warnonly in makedocs to make such issues non-breaking, but if that's not the proper way to do it, please let me know and I can change it.


## :ballot_box_with_check: Checklist

- [X] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [X] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [X] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [X] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [X] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
